### PR TITLE
fix: Extension filepaths are misinterpreted as URL

### DIFF
--- a/Classes/Provider/CssIconProvider.php
+++ b/Classes/Provider/CssIconProvider.php
@@ -283,7 +283,7 @@ class CssIconProvider extends AbstractIconProvider
     {
         $fontFileUrl = static::cleanFilePath($fontFilePath);
         $isRemoteFontPath = GeneralUtility::isValidUrl($fontFileUrl);
-        $isRemoteStylesheet = GeneralUtility::isValidUrl($this->options['file']);
+        $isRemoteStylesheet = GeneralUtility::isValidUrl($this->options['file']) && strpos($path, 'EXT:') != 0;
         $fontFileName = pathinfo($fontFilePath, PATHINFO_BASENAME);
 
         if ($isRemoteFontPath) {


### PR DESCRIPTION
When try downloading the font file, there was a missing check for EXT: file paths.

See issue https://github.com/maikschneider/bw_icons/issues/58